### PR TITLE
fix(ex3 ex4): fix assign variable before and expression

### DIFF
--- a/ex-3.js
+++ b/ex-3.js
@@ -1,8 +1,9 @@
 // Exercise #3: Celsius to Fahrenheit
 let celsius = 30;
+let fahrenheit;
 
 fahrenheit = (celsius*1.8)+32;
 
+//console.log(fahrenheit);
 
 
-let fahrenheit;

--- a/ex-4.js
+++ b/ex-4.js
@@ -6,8 +6,10 @@
 let zero = 1000 - 1000;
 20 * 120; // Expression
 1000 / 2; // Expression
-typeof true;
+typeof true;  // Expression
 let name = "John";
 3 > 5; // Expression
-10 == 100;
-200;
+10 == 100; // Expression
+200; // Expression
+
+


### PR DESCRIPTION
I address some issues in ex3 and ex4 krub.

Proposed solution:  In ex3 I brought the let variable before the calculation  and in ex4 some expressions are identified additionally.